### PR TITLE
add round trip tests

### DIFF
--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -48,10 +48,10 @@ use jni::signature::JavaType;
 use jni::sys::{jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jobject, jshort};
 use paste::paste;
 
+pub use field::*;
 pub use robusta_codegen::Signature;
 pub use safe::*;
 pub use unchecked::*;
-pub use field::*;
 
 pub mod safe;
 pub mod unchecked;
@@ -89,7 +89,7 @@ macro_rules! jvalue_types {
             fn autobox(self, env: &JNIEnv<'env>) -> JObject<'env> {
                 env.call_static_method_unchecked(concat!("java/lang/", stringify!($boxed)),
                     (concat!("java/lang/", stringify!($boxed)), "valueOf", concat!(stringify!(($sig)), "Ljava/lang/", stringify!($boxed), ";")),
-                    JavaType::from_str(concat!("java/lang/", stringify!($boxed))).unwrap(),
+                    JavaType::from_str(concat!("Ljava/lang/", stringify!($boxed), ";")).unwrap(),
                     &[Into::into(self)]).unwrap().l().unwrap()
             }
 

--- a/tests/driver/native/src/lib.rs
+++ b/tests/driver/native/src/lib.rs
@@ -55,6 +55,8 @@ pub mod jni {
 
         pub extern "jni" fn getString(self, v: String) -> String { v }
 
+        pub extern "jni" fn getIntArray(self, v: Vec<i32>) -> Vec<i32> { v }
+
         pub extern "jni" fn getStringArray(self, v: Vec<String>) -> Vec<String> { v }
 
         pub extern "jni" fn intToString(self, v: i32) -> String { format!("{}", v) }
@@ -72,6 +74,8 @@ pub mod jni {
         pub extern "jni" fn longToString(self, v: i64) -> String { format!("{}", v) }
 
         pub extern "jni" fn shortToString(self, v: i16) -> String { format!("{}", v) }
+
+        pub extern "jni" fn intArrayToString(self, v: Vec<i32>) -> String { format!("{:?}", v) }
 
         pub extern "jni" fn stringArrayToString(self, v: Vec<String>) -> String { format!("{:?}", v) }
 

--- a/tests/driver/native/src/lib.rs
+++ b/tests/driver/native/src/lib.rs
@@ -37,7 +37,25 @@ pub mod jni {
             user_pw + "_pass"
         }
 
-        pub extern "jni" fn getBool(self, b: bool) -> bool { b }
+        pub extern "jni" fn getInt(self, v: i32) -> i32 { v }
+
+        pub extern "jni" fn getBool(self, v: bool) -> bool { v }
+
+        pub extern "jni" fn getChar(self, v: char) -> char { v }
+
+        pub extern "jni" fn getByte(self, v: i8) -> i8 { v }
+
+        pub extern "jni" fn getFloat(self, v: f32) -> f32 { v }
+
+        pub extern "jni" fn getDouble(self, v: f64) -> f64 { v }
+
+        pub extern "jni" fn getLong(self, v: i64) -> i64 { v }
+
+        pub extern "jni" fn getShort(self, v: i16) -> i16 { v }
+
+        pub extern "jni" fn getString(self, v: String) -> String { v }
+
+        pub extern "jni" fn getStringArray(self, v: Vec<String>) -> Vec<String> { v }
 
         pub extern "java" fn getPassword(&self, env: &JNIEnv) -> ::robusta_jni::jni::errors::Result<String> {}
 

--- a/tests/driver/native/src/lib.rs
+++ b/tests/driver/native/src/lib.rs
@@ -57,6 +57,24 @@ pub mod jni {
 
         pub extern "jni" fn getStringArray(self, v: Vec<String>) -> Vec<String> { v }
 
+        pub extern "jni" fn intToString(self, v: i32) -> String { format!("{}", v) }
+
+        pub extern "jni" fn boolToString(self, v: bool) -> String { format!("{}", v) }
+
+        pub extern "jni" fn charToString(self, v: char) -> String { format!("{}", v) }
+
+        pub extern "jni" fn byteToString(self, v: i8) -> String { format!("{}", v) }
+
+        pub extern "jni" fn floatToString(self, v: f32) -> String { format!("{}", v) }
+
+        pub extern "jni" fn doubleToString(self, v: f64) -> String { format!("{}", v) }
+
+        pub extern "jni" fn longToString(self, v: i64) -> String { format!("{}", v) }
+
+        pub extern "jni" fn shortToString(self, v: i16) -> String { format!("{}", v) }
+
+        pub extern "jni" fn stringArrayToString(self, v: Vec<String>) -> String { format!("{:?}", v) }
+
         pub extern "java" fn getPassword(&self, env: &JNIEnv) -> ::robusta_jni::jni::errors::Result<String> {}
 
         pub extern "java" fn getTotalUsersCount(env: &JNIEnv) -> ::robusta_jni::jni::errors::Result<i32> {}

--- a/tests/driver/src/main/java/User.java
+++ b/tests/driver/src/main/java/User.java
@@ -31,6 +31,24 @@ public class User {
 
     public native List<String> getStringArray(List<String> x);
 
+    public native String intToString(int x);
+
+    public native String boolToString(boolean x);
+
+    public native String charToString(char x);
+
+    public native String byteToString(byte x);
+
+    public native String floatToString(float x);
+
+    public native String doubleToString(double x);
+
+    public native String longToString(long x);
+
+    public native String shortToString(short x);
+
+    public native String stringArrayToString(List<String> x);
+
     private native static void initNative();
 
     public native static String userCountStatus();

--- a/tests/driver/src/main/java/User.java
+++ b/tests/driver/src/main/java/User.java
@@ -1,3 +1,6 @@
+import java.util.ArrayList;
+import java.util.List;
+
 public class User {
     static {
         System.loadLibrary("native");
@@ -9,7 +12,25 @@ public class User {
     private String username;
     private String password;
 
+    public native int getInt(int x);
+
     public native boolean getBool(boolean x);
+
+    public native char getChar(char x);
+
+    public native byte getByte(byte x);
+
+    public native float getFloat(float x);
+
+    public native double getDouble(double x);
+
+    public native long getLong(long x);
+
+    public native short getShort(short x);
+
+    public native String getString(String x);
+
+    public native List<String> getStringArray(List<String> x);
 
     private native static void initNative();
 

--- a/tests/driver/src/main/java/User.java
+++ b/tests/driver/src/main/java/User.java
@@ -1,4 +1,3 @@
-import java.util.ArrayList;
 import java.util.List;
 
 public class User {

--- a/tests/driver/src/main/java/User.java
+++ b/tests/driver/src/main/java/User.java
@@ -29,6 +29,8 @@ public class User {
 
     public native String getString(String x);
 
+    public native List<Integer> getIntArray(List<Integer> x);
+
     public native List<String> getStringArray(List<String> x);
 
     public native String intToString(int x);
@@ -46,6 +48,8 @@ public class User {
     public native String longToString(long x);
 
     public native String shortToString(short x);
+
+    public native String intArrayToString(List<Integer> x);
 
     public native String stringArrayToString(List<String> x);
 

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -107,7 +107,6 @@ public class UserTest {
         assertValueRoundTrip(u::getString, "아주 좋습니다");
         // pirate flag https://unicode.org/emoji/charts/emoji-zwj-sequences.html
         assertValueRoundTrip(u::getString, "️🏴‍☠️");
-        assertValueRoundTrip(u::getString, "️🏴‍☠️");
     }
 
     @Test

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -107,6 +107,7 @@ public class UserTest {
         assertValueRoundTrip(u::getString, "아주 좋습니다");
         // pirate flag https://unicode.org/emoji/charts/emoji-zwj-sequences.html
         assertValueRoundTrip(u::getString, "️🏴‍☠️");
+        assertValueRoundTrip(u::getString, "️️𒅄"); // 4 bytes in utf-8
     }
 
     @Test

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UserTest {
     private User u;

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -23,97 +23,110 @@ public class UserTest {
 
     @Test
     public void intTest() {
-        assertValueRoundTrip(u::getInt, 0);
-        assertValueRoundTrip(u::getInt, 1);
-        assertValueRoundTrip(u::getInt, -1);
-        assertValueRoundTrip(u::getInt, Integer.MAX_VALUE);
-        assertValueRoundTrip(u::getInt, Integer.MIN_VALUE);
+        assertValueRoundTrip(u::getInt, u::intToString, 0, "0");
+        assertValueRoundTrip(u::getInt, u::intToString, 1, "1");
+        assertValueRoundTrip(u::getInt, u::intToString, -1, "-1");
+        assertValueRoundTrip(u::getInt, u::intToString, Integer.MAX_VALUE, "2147483647");
+        assertValueRoundTrip(u::getInt, u::intToString, Integer.MIN_VALUE, "-2147483648");
     }
 
     @Test
     public void boolTest() {
-        assertValueRoundTrip(u::getBool, false);
-        assertValueRoundTrip(u::getBool, true);
+        assertValueRoundTrip(u::getBool, u::boolToString, false, "false");
+        assertValueRoundTrip(u::getBool, u::boolToString, true, "true");
     }
 
     @Test
     public void charTest() {
-        assertValueRoundTrip(u::getChar, 'a');
-        assertValueRoundTrip(u::getChar, '\n');
-        assertValueRoundTrip(u::getChar, '你');
-        assertValueRoundTrip(u::getChar, Character.MIN_VALUE);
-        assertValueRoundTrip(u::getChar, Character.MAX_VALUE); // note: Character.MAX_VALUE != char::MAX
+        assertValueRoundTrip(u::getChar, u::charToString, 'a', "a");
+        assertValueRoundTrip(u::getChar, u::charToString, '\n', "\n");
+        assertValueRoundTrip(u::getChar, u::charToString, '你', "你");
+        assertValueRoundTrip(u::getChar, u::charToString, Character.MIN_VALUE, "\0");
+        // note: Character.MAX_VALUE != char::MAX
+        assertValueRoundTrip(u::getChar, u::charToString, Character.MAX_VALUE, "\uffff");
     }
 
     @Test
     public void byteTest() {
-        assertValueRoundTrip(u::getByte, (byte) 0);
-        assertValueRoundTrip(u::getByte, (byte) 1);
-        assertValueRoundTrip(u::getByte, (byte) -1);
-        assertValueRoundTrip(u::getByte, Byte.MAX_VALUE);
-        assertValueRoundTrip(u::getByte, Byte.MIN_VALUE);
+        assertValueRoundTrip(u::getByte, u::byteToString, (byte) 0, "0");
+        assertValueRoundTrip(u::getByte, u::byteToString, (byte) 1, "1");
+        assertValueRoundTrip(u::getByte, u::byteToString, (byte) -1, "-1");
+        assertValueRoundTrip(u::getByte, u::byteToString, Byte.MAX_VALUE, "127");
+        assertValueRoundTrip(u::getByte, u::byteToString, Byte.MIN_VALUE, "-128");
     }
 
     @Test
     public void floatTest() {
-        assertValueRoundTrip(u::getFloat, (float) 0.0);
-        assertValueRoundTrip(u::getFloat, (float) 1.23);
-        assertValueRoundTrip(u::getFloat, (float) -123.45);
-        assertValueRoundTrip(u::getFloat, Float.MAX_VALUE);
-        assertValueRoundTrip(u::getFloat, Float.MIN_VALUE);
-        assertValueRoundTrip(u::getFloat, Float.NaN);
-        assertValueRoundTrip(u::getFloat, Float.MIN_NORMAL);
-        assertValueRoundTrip(u::getFloat, Float.POSITIVE_INFINITY);
-        assertValueRoundTrip(u::getFloat, Float.NEGATIVE_INFINITY);
+        assertValueRoundTrip(u::getFloat, u::floatToString, (float) 0.0, "0");
+        assertValueRoundTrip(u::getFloat, u::floatToString, (float) 1.23, "1.23");
+        assertValueRoundTrip(u::getFloat, u::floatToString, (float) -123.45, "-123.45");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.MAX_VALUE, "340282350000000000000000000000000000000");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.MIN_VALUE, "0.000000000000000000000000000000000000000000001");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.NaN, "NaN");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.MIN_NORMAL, "0.000000000000000000000000000000000000011754944");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.POSITIVE_INFINITY, "inf");
+        assertValueRoundTrip(u::getFloat, u::floatToString, Float.NEGATIVE_INFINITY, "-inf");
     }
 
     @Test
     public void doubleTest() {
-        assertValueRoundTrip(u::getDouble, 0.0);
-        assertValueRoundTrip(u::getDouble, 1.23);
-        assertValueRoundTrip(u::getDouble, -123.45);
-        assertValueRoundTrip(u::getDouble, Double.MAX_VALUE);
-        assertValueRoundTrip(u::getDouble, Double.MIN_VALUE);
-        assertValueRoundTrip(u::getDouble, Double.NaN);
-        assertValueRoundTrip(u::getDouble, Double.MIN_NORMAL);
-        assertValueRoundTrip(u::getDouble, Double.POSITIVE_INFINITY);
-        assertValueRoundTrip(u::getDouble, Double.NEGATIVE_INFINITY);
+        assertValueRoundTrip(u::getDouble, u::doubleToString, 0.0, "0");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, 1.23, "1.23");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, -123.45, "-123.45");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.MAX_VALUE,
+                "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "000000000000000000000000000000000000");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.MIN_VALUE,
+                "0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "00000000000000000000000000000000000000000000000000005");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.NaN, "NaN");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.MIN_NORMAL,
+                "0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+                        "00000000000000000000000000000000000000022250738585072014");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.POSITIVE_INFINITY, "inf");
+        assertValueRoundTrip(u::getDouble, u::doubleToString, Double.NEGATIVE_INFINITY, "-inf");
     }
 
     @Test
     public void longTest() {
-        assertValueRoundTrip(u::getLong, 0L);
-        assertValueRoundTrip(u::getLong, 1L);
-        assertValueRoundTrip(u::getLong, -1L);
-        assertValueRoundTrip(u::getLong, Long.MAX_VALUE);
-        assertValueRoundTrip(u::getLong, Long.MIN_VALUE);
+        assertValueRoundTrip(u::getLong, u::longToString, 0L, "0");
+        assertValueRoundTrip(u::getLong, u::longToString, 1L, "1");
+        assertValueRoundTrip(u::getLong, u::longToString, -1L, "-1");
+        assertValueRoundTrip(u::getLong, u::longToString, Long.MAX_VALUE, "9223372036854775807");
+        assertValueRoundTrip(u::getLong, u::longToString, Long.MIN_VALUE, "-9223372036854775808");
     }
 
     @Test
     public void shortTest() {
-        assertValueRoundTrip(u::getShort, (short) 0);
-        assertValueRoundTrip(u::getShort, (short) 1);
-        assertValueRoundTrip(u::getShort, (short) -1);
-        assertValueRoundTrip(u::getShort, Short.MAX_VALUE);
-        assertValueRoundTrip(u::getShort, Short.MIN_VALUE);
+        assertValueRoundTrip(u::getShort, u::shortToString, (short) 0, "0");
+        assertValueRoundTrip(u::getShort, u::shortToString, (short) 1, "1");
+        assertValueRoundTrip(u::getShort, u::shortToString, (short) -1, "-1");
+        assertValueRoundTrip(u::getShort, u::shortToString, Short.MAX_VALUE, "32767");
+        assertValueRoundTrip(u::getShort, u::shortToString, Short.MIN_VALUE, "-32768");
     }
 
     @Test
     public void stringTest() {
-        assertValueRoundTrip(u::getString, "");
-        assertValueRoundTrip(u::getString, "hello!");
-        assertValueRoundTrip(u::getString, "a".repeat(10000));
-        assertValueRoundTrip(u::getString, "\0a\rb\nc\t");
-        assertValueRoundTrip(u::getString, "아주 좋습니다");
+        assertValueRoundTrip(u::getString, Function.identity(), "", "");
+        assertValueRoundTrip(u::getString, Function.identity(), "hello!", "hello!");
+        assertValueRoundTrip(u::getString, Function.identity(), "a".repeat(10000), "a".repeat(10000));
+        assertValueRoundTrip(u::getString, Function.identity(), "\0a\rb\nc\t", "\0a\rb\nc\t");
+        assertValueRoundTrip(u::getString, Function.identity(), "아주 좋습니다", "아주 좋습니다");
         // pirate flag https://unicode.org/emoji/charts/emoji-zwj-sequences.html
-        assertValueRoundTrip(u::getString, "️🏴‍☠️");
-        assertValueRoundTrip(u::getString, "️️𒅄"); // 4 bytes in utf-8
+        assertValueRoundTrip(u::getString, Function.identity(), "️🏴‍☠️", "️🏴‍☠️");
+        assertValueRoundTrip(u::getString, Function.identity(), "️️𒅄", "️️𒅄"); // 4 bytes in utf-8
     }
 
     @Test
     public void stringArrayTest() {
-        assertValueRoundTrip(u::getStringArray, List.of());
-        assertValueRoundTrip(u::getStringArray, List.of("a", "b", "c"));
+        assertValueRoundTrip(u::getStringArray, u::stringArrayToString, List.of(), "[]");
+        assertValueRoundTrip(u::getStringArray, u::stringArrayToString, List.of("a", "b", "c"), "[\"a\", \"b\", \"c\"]");
     }
 
     @Test
@@ -121,7 +134,8 @@ public class UserTest {
         assertEquals(String.valueOf(User.getTotalUsersCount()), User.userCountStatus());
     }
 
-    private <T> void assertValueRoundTrip(Function<T, T> func, T value) {
+    private <T> void assertValueRoundTrip(Function<T, T> func, Function<T, String> toString, T value, String text) {
         assertEquals(value, func.apply(value));
+        assertEquals(text, toString.apply(value));
     }
 }

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -1,7 +1,11 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UserTest {
     private User u;
@@ -19,13 +23,106 @@ public class UserTest {
     }
 
     @Test
+    public void intTest() {
+        assertValueRoundTrip(u::getInt, 0);
+        assertValueRoundTrip(u::getInt, 1);
+        assertValueRoundTrip(u::getInt, -1);
+        assertValueRoundTrip(u::getInt, Integer.MAX_VALUE);
+        assertValueRoundTrip(u::getInt, Integer.MIN_VALUE);
+    }
+
+    @Test
     public void boolTest() {
-        boolean expected = true;
-        assertEquals(u.getBool(expected), expected);
+        assertValueRoundTrip(u::getBool, false);
+        assertValueRoundTrip(u::getBool, true);
+    }
+
+    @Test
+    public void charTest() {
+        assertValueRoundTrip(u::getChar, 'a');
+        assertValueRoundTrip(u::getChar, '\n');
+        assertValueRoundTrip(u::getChar, '你');
+        assertValueRoundTrip(u::getChar, Character.MIN_VALUE);
+        assertValueRoundTrip(u::getChar, Character.MAX_VALUE); // note: Character.MAX_VALUE != char::MAX
+    }
+
+    @Test
+    public void byteTest() {
+        assertValueRoundTrip(u::getByte, (byte) 0);
+        assertValueRoundTrip(u::getByte, (byte) 1);
+        assertValueRoundTrip(u::getByte, (byte) -1);
+        assertValueRoundTrip(u::getByte, Byte.MAX_VALUE);
+        assertValueRoundTrip(u::getByte, Byte.MIN_VALUE);
+    }
+
+    @Test
+    public void floatTest() {
+        assertValueRoundTrip(u::getFloat, (float) 0.0);
+        assertValueRoundTrip(u::getFloat, (float) 1.23);
+        assertValueRoundTrip(u::getFloat, (float) -123.45);
+        assertValueRoundTrip(u::getFloat, Float.MAX_VALUE);
+        assertValueRoundTrip(u::getFloat, Float.MIN_VALUE);
+        assertValueRoundTrip(u::getFloat, Float.NaN);
+        assertValueRoundTrip(u::getFloat, Float.MIN_NORMAL);
+        assertValueRoundTrip(u::getFloat, Float.POSITIVE_INFINITY);
+        assertValueRoundTrip(u::getFloat, Float.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    public void doubleTest() {
+        assertValueRoundTrip(u::getDouble, 0.0);
+        assertValueRoundTrip(u::getDouble, 1.23);
+        assertValueRoundTrip(u::getDouble, -123.45);
+        assertValueRoundTrip(u::getDouble, Double.MAX_VALUE);
+        assertValueRoundTrip(u::getDouble, Double.MIN_VALUE);
+        assertValueRoundTrip(u::getDouble, Double.NaN);
+        assertValueRoundTrip(u::getDouble, Double.MIN_NORMAL);
+        assertValueRoundTrip(u::getDouble, Double.POSITIVE_INFINITY);
+        assertValueRoundTrip(u::getDouble, Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    public void longTest() {
+        assertValueRoundTrip(u::getLong, 0L);
+        assertValueRoundTrip(u::getLong, 1L);
+        assertValueRoundTrip(u::getLong, -1L);
+        assertValueRoundTrip(u::getLong, Long.MAX_VALUE);
+        assertValueRoundTrip(u::getLong, Long.MIN_VALUE);
+    }
+
+    @Test
+    public void shortTest() {
+        assertValueRoundTrip(u::getShort, (short) 0);
+        assertValueRoundTrip(u::getShort, (short) 1);
+        assertValueRoundTrip(u::getShort, (short) -1);
+        assertValueRoundTrip(u::getShort, Short.MAX_VALUE);
+        assertValueRoundTrip(u::getShort, Short.MIN_VALUE);
+    }
+
+    @Test
+    public void stringTest() {
+        assertValueRoundTrip(u::getString, "");
+        assertValueRoundTrip(u::getString, "hello!");
+        assertValueRoundTrip(u::getString, "a".repeat(10000));
+        assertValueRoundTrip(u::getString, "\0a\rb\nc\t");
+        assertValueRoundTrip(u::getString, "아주 좋습니다");
+        // pirate flag https://unicode.org/emoji/charts/emoji-zwj-sequences.html
+        assertValueRoundTrip(u::getString, "️🏴‍☠️");
+        assertValueRoundTrip(u::getString, "️🏴‍☠️");
+    }
+
+    @Test
+    public void stringArrayTest() {
+        assertValueRoundTrip(u::getStringArray, List.of());
+        assertValueRoundTrip(u::getStringArray, List.of("a", "b", "c"));
     }
 
     @Test
     public void staticMethod() {
         assertEquals(String.valueOf(User.getTotalUsersCount()), User.userCountStatus());
+    }
+
+    private <T> void assertValueRoundTrip(Function<T, T> func, T value) {
+        assertEquals(value, func.apply(value));
     }
 }

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -124,6 +124,12 @@ public class UserTest {
     }
 
     @Test
+    public void intArrayTest() {
+        assertValueRoundTrip(u::getIntArray, u::intArrayToString, List.of(), "[]");
+        assertValueRoundTrip(u::getIntArray, u::intArrayToString, List.of(1, 2), "[1, 2]");
+    }
+
+    @Test
     public void stringArrayTest() {
         assertValueRoundTrip(u::getStringArray, u::stringArrayToString, List.of(), "[]");
         assertValueRoundTrip(u::getStringArray, u::stringArrayToString, List.of("a", "b", "c"), "[\"a\", \"b\", \"c\"]");

--- a/tests/driver/src/test/java/UserTest.java
+++ b/tests/driver/src/test/java/UserTest.java
@@ -1,7 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 


### PR DESCRIPTION
closes #11

Compiler complained about using `extern "jni"` with `macro_rules`. Maybe the macros were applied in the wrong order or something.