### PR TITLE
Repair multiple parameters java function

### DIFF
--- a/robusta-codegen/src/transformation/imported.rs
+++ b/robusta-codegen/src/transformation/imported.rs
@@ -131,6 +131,7 @@ impl<'ctx> Fold for ImportedMethodTransformer<'ctx> {
                 let input_types_conversions = signature
                     .inputs
                     .iter_mut()
+                    .rev()
                     .filter_map(|i| match i {
                         FnArg::Typed(t) => match &*t.pat {
                             Pat::Ident(PatIdent { ident, .. }) if ident == "self" => None,

--- a/tests/driver/native/src/lib.rs
+++ b/tests/driver/native/src/lib.rs
@@ -83,6 +83,8 @@ pub mod jni {
 
         pub extern "java" fn getTotalUsersCount(env: &JNIEnv) -> ::robusta_jni::jni::errors::Result<i32> {}
 
+        pub extern "java" fn multipleParameters(&self, env: &JNIEnv, v: i32, s: String) -> ::robusta_jni::jni::errors::Result<String> {}
+
         #[constructor]
         pub extern "java" fn new(env: &'borrow JNIEnv<'env>, username: String, password: String) -> JniResult<Self> {}
     }

--- a/tests/driver/src/main/java/User.java
+++ b/tests/driver/src/main/java/User.java
@@ -73,4 +73,8 @@ public class User {
     public String getPassword() {
         return password;
     }
+
+    public String multipleParameters(int i, String s) {
+        return s;
+    }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -69,5 +69,7 @@ fn vm_creation_and_object_usage() {
         .expect("can't get user count");
     assert_eq!(count, 1);
 
-    assert_eq!(u.getPassword(&env).expect("can't get user password"), "password")
+    assert_eq!(u.getPassword(&env).expect("can't get user password"), "password");
+
+    assert_eq!(u.multipleParameters(&env, 10, "test".to_string()).expect("Can't test multipleParameters"), "test")
 }


### PR DESCRIPTION
There is an issue on rust to java call when there is multiple parameters as there aren't processed in the right order.